### PR TITLE
fix routing graph construction and calculation of shortest route

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 project(libOpenDrive VERSION 0.3.0 DESCRIPTION ".xodr library")
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 set(CMAKE_CXX_FLAGS "-Wall")

--- a/include/Lane.h
+++ b/include/Lane.h
@@ -24,12 +24,21 @@ struct HeightOffset
 
 struct LaneKey
 {
+    LaneKey() = default;
     LaneKey(std::string road_id, double lanesection_s0, int lane_id);
     std::string to_string() const;
 
     std::string road_id = "";
     double      lanesection_s0 = 0;
     int         lane_id = 0;
+
+    // Overload the equality operator
+    bool operator==(const LaneKey& other) const
+    {
+        return road_id == other.road_id && lanesection_s0 == other.lanesection_s0 && lane_id == other.lane_id;
+    }
+
+    bool operator!=(const LaneKey& other) const { return !(*this == other); }
 };
 
 struct Lane : public XmlNode

--- a/include/OpenDriveMap.h
+++ b/include/OpenDriveMap.h
@@ -31,6 +31,9 @@ public:
     RoadNetworkMesh get_road_network_mesh(const double eps) const;
     RoutingGraph    get_routing_graph() const;
 
+    std::vector<Lane> find_lane_predecessors(const Lane& lane) const;
+    std::vector<Lane> find_lane_successors(const Lane& lane) const;
+
     std::string        proj4 = "";
     double             x_offs = 0;
     double             y_offs = 0;

--- a/include/Road.h
+++ b/include/Road.h
@@ -12,6 +12,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <optional>
 
 namespace odr
 {
@@ -92,6 +93,9 @@ public:
     double get_lanesection_end(const double lanesection_s0) const;
     double get_lanesection_length(const LaneSection& lanesection) const;
     double get_lanesection_length(const double lanesection_s0) const;
+
+    std::optional<LaneSection> get_next_lanesection(const LaneSection& lanesection) const;
+    std::optional<LaneSection> get_previous_lanesection(const LaneSection& lanesection) const;
 
     Vec3D get_xyz(const double s, const double t, const double h, Vec3D* e_s = nullptr, Vec3D* e_t = nullptr, Vec3D* e_h = nullptr) const;
     Vec3D get_surface_pt(double s, const double t, Vec3D* vn = nullptr) const;

--- a/include/RoutingGraph.h
+++ b/include/RoutingGraph.h
@@ -69,6 +69,10 @@ struct equal_to<odr::WeightedLaneKey>
 
 namespace odr
 {
+struct CompareLaneKey
+{
+    bool operator()(const WeightedLaneKey& lhs, const WeightedLaneKey& rhs) const { return lhs.weight > rhs.weight; }
+};
 
 class RoutingGraph
 {

--- a/src/OpenDriveMap.cpp
+++ b/src/OpenDriveMap.cpp
@@ -797,15 +797,19 @@ RoutingGraph OpenDriveMap::get_routing_graph() const
 
             const LaneSection& incoming_lanesec =
                 is_succ_junc ? incoming_road.s_to_lanesection.rbegin()->second : incoming_road.s_to_lanesection.begin()->second;
+
             const LaneSection& connecting_lanesec = (conn.contact_point == JunctionConnection::ContactPoint_Start)
                                                         ? connecting_road.s_to_lanesection.begin()->second
                                                         : connecting_road.s_to_lanesection.rbegin()->second;
+
             for (const JunctionLaneLink& lane_link : conn.lane_links)
             {
                 if (lane_link.from == 0 || lane_link.to == 0)
                     continue;
+
                 auto from_lane_iter = incoming_lanesec.id_to_lane.find(lane_link.from);
                 auto to_lane_iter = connecting_lanesec.id_to_lane.find(lane_link.to);
+
                 if (from_lane_iter == incoming_lanesec.id_to_lane.end() || to_lane_iter == connecting_lanesec.id_to_lane.end())
                     continue;
                 const Lane& from_lane = from_lane_iter->second;
@@ -814,6 +818,7 @@ RoutingGraph OpenDriveMap::get_routing_graph() const
                 const LaneKey from(incoming_road.id, incoming_lanesec.s0, from_lane.id);
                 const LaneKey to(connecting_road.id, connecting_lanesec.s0, to_lane.id);
                 const double  lane_length = incoming_road.get_lanesection_length(incoming_lanesec);
+
                 routing_graph.add_edge(RoutingGraphEdge(from, to, lane_length));
             }
         }
@@ -836,18 +841,22 @@ std::vector<Lane> OpenDriveMap::find_lane_predecessors(const Lane& lane) const
     else
         prev_lanesection = current_road.get_next_lanesection(current_lanesection);
 
-    // if roadlinks at the correct end use those
-    const RoadLink& road_link = lane_follows_road_direction ? current_road.predecessor : current_road.successor;
-    if (!(road_link.type != RoadLink::Type_Road || road_link.contact_point == RoadLink::ContactPoint_None))
+    if (!prev_lanesection)
     {
-        auto next_road_iter = this->id_to_road.find(road_link.id);
-        if (!(next_road_iter == this->id_to_road.end()))
+        // if roadlinks at the correct end use those
+        const RoadLink& road_link = lane_follows_road_direction ? current_road.predecessor : current_road.successor;
+        if (!(road_link.type != RoadLink::Type_Road || road_link.contact_point == RoadLink::ContactPoint_None))
         {
-            const Road& next_road = next_road_iter->second;
-            prev_lanesection = (road_link.contact_point == RoadLink::ContactPoint_Start) ? next_road.s_to_lanesection.begin()->second
-                                                                                         : next_road.s_to_lanesection.rbegin()->second;
+            auto next_road_iter = this->id_to_road.find(road_link.id);
+            if (!(next_road_iter == this->id_to_road.end()))
+            {
+                const Road& next_road = next_road_iter->second;
+                prev_lanesection = (road_link.contact_point == RoadLink::ContactPoint_Start) ? next_road.s_to_lanesection.begin()->second
+                                                                                             : next_road.s_to_lanesection.rbegin()->second;
+            }
         }
     }
+
     if (prev_lanesection)
     {
         // Check if the optional next_lanesection has a value
@@ -891,17 +900,20 @@ std::vector<Lane> OpenDriveMap::find_lane_successors(const Lane& lane) const
 
     // if roadlinks at the correct end use those
     const RoadLink& road_link = lane_follows_road_direction ? current_road.successor : current_road.predecessor;
-
-    if (!(road_link.type != RoadLink::Type_Road || road_link.contact_point == RoadLink::ContactPoint_None))
+    if (!next_lanesection)
     {
-        auto next_road_iter = this->id_to_road.find(road_link.id);
-        if (!(next_road_iter == this->id_to_road.end()))
+        if (!(road_link.type != RoadLink::Type_Road || road_link.contact_point == RoadLink::ContactPoint_None))
         {
-            const Road& next_road = next_road_iter->second;
-            next_lanesection = (road_link.contact_point == RoadLink::ContactPoint_Start) ? next_road.s_to_lanesection.begin()->second
-                                                                                         : next_road.s_to_lanesection.rbegin()->second;
+            auto next_road_iter = this->id_to_road.find(road_link.id);
+            if (!(next_road_iter == this->id_to_road.end()))
+            {
+                const Road& next_road = next_road_iter->second;
+                next_lanesection = (road_link.contact_point == RoadLink::ContactPoint_Start) ? next_road.s_to_lanesection.begin()->second
+                                                                                             : next_road.s_to_lanesection.rbegin()->second;
+            }
         }
     }
+
     if (next_lanesection)
     {
         // Check if the optional next_lanesection has a value

--- a/src/Road.cpp
+++ b/src/Road.cpp
@@ -557,5 +557,31 @@ Mesh3D Road::get_road_object_mesh(const RoadObject& road_object, const double ep
 
     return road_obj_mesh;
 }
-
+std::optional<LaneSection> Road::get_next_lanesection(const LaneSection& lanesection) const
+{
+    auto it = s_to_lanesection.upper_bound(lanesection.s0);
+    if (it != s_to_lanesection.end())
+    {
+        return (it->second);
+    }
+    else
+    {
+        // If there is no next lanesection, return a null pointer.
+        return std::nullopt;
+    }
+}
+std::optional<LaneSection> Road::get_previous_lanesection(const LaneSection& lanesection) const
+{
+    if (s_to_lanesection.size() <= 1)
+    {
+        return std::nullopt; // No previous section if this is the only one or map is empty
+    }
+    auto it = s_to_lanesection.lower_bound(lanesection.s0);
+    if (it != s_to_lanesection.begin())
+    {
+        --it; // Safe to decrement since we're not at the beginning
+        return (it->second);
+    }
+    return std::nullopt; // If at the beginning, no previous section exists
+}
 } // namespace odr

--- a/src/RoutingGraph.cpp
+++ b/src/RoutingGraph.cpp
@@ -3,7 +3,8 @@
 #include <algorithm>
 #include <limits>
 #include <utility>
-
+#include <queue>
+#include <iostream>
 namespace odr
 {
 
@@ -36,76 +37,73 @@ std::vector<LaneKey> RoutingGraph::get_lane_predecessors(const LaneKey& lane_key
     std::vector<LaneKey>                predecessor_lane_keys(res.begin(), res.end());
     return predecessor_lane_keys;
 }
-
 std::vector<LaneKey> RoutingGraph::shortest_path(const LaneKey& from, const LaneKey& to) const
 {
-    std::vector<LaneKey> path;
-    if (this->lane_key_to_successors.count(from) == 0)
-        return path;
+    std::cout << "calculating route" << std::endl;
+    // Using a min-heap to represent the open set
+    std::priority_queue<WeightedLaneKey, std::vector<WeightedLaneKey>, CompareLaneKey> open_set;
 
-    std::unordered_set<LaneKey> vertices;
-    for (const auto& lane_key_successors : this->lane_key_to_successors)
+    // Maps to keep track of the best cost from start to a node and the best previous node to reach a node
+    std::unordered_map<LaneKey, double>  cost_from_start;
+    std::unordered_map<LaneKey, LaneKey> came_from;
+
+    // Initialize the start node in the open set with zero cost
+    cost_from_start[from] = 0.0;
+    open_set.push(WeightedLaneKey(from, 0.0));
+
+    while (!open_set.empty())
     {
-        vertices.insert(lane_key_successors.first);
-        vertices.insert(lane_key_successors.second.begin(), lane_key_successors.second.end());
-    }
+        WeightedLaneKey current_weighted = open_set.top();
+        LaneKey         current = current_weighted;
+        open_set.pop();
 
-    if (vertices.count(to) == 0)
-        return path;
-
-    std::vector<LaneKey>                 nodes;
-    std::unordered_map<LaneKey, double>  weights;
-    std::unordered_map<LaneKey, LaneKey> previous;
-
-    auto comparator = [&](const LaneKey& lhs, const LaneKey& rhs) { return weights[lhs] > weights[rhs]; };
-    for (const auto& lane_key : vertices)
-    {
-        if (std::equal_to<odr::LaneKey>{}(lane_key, from))
-            weights[lane_key] = 0;
-        else
-            weights[lane_key] = std::numeric_limits<double>::max();
-        nodes.push_back(lane_key);
-        std::push_heap(nodes.begin(), nodes.end(), comparator);
-    }
-
-    while (nodes.empty() == false)
-    {
-        std::pop_heap(nodes.begin(), nodes.end(), comparator);
-        LaneKey smallest = nodes.back();
-        nodes.pop_back();
-
-        if (std::equal_to<LaneKey>{}(smallest, to))
+        // If the goal is reached, stop and construct the path
+        if (current == to)
         {
-            while (previous.find(smallest) != previous.end())
+            std::vector<LaneKey> path;
+            for (LaneKey at = to; at != from; at = came_from[at])
             {
-                path.push_back(smallest);
-                smallest = previous.at(smallest);
+                path.push_back(at);
             }
-            break;
+            path.push_back(from);
+            std::reverse(path.begin(), path.end());
+            std::cout << "found route" << std::endl;
+            return path;
+        }
+        // Check if this is a stale entry
+        if (current_weighted.weight > cost_from_start[current])
+        {
+            continue; // Skip processing this node because we have found a better path
+        }
+        // Access successors safely
+        auto succ_itr = this->lane_key_to_successors.find(current);
+        if (succ_itr == this->lane_key_to_successors.end())
+        {
+            continue; // No successors for the current node, skip it
         }
 
-        if (weights.at(smallest) == std::numeric_limits<double>::max())
-            break;
-
-        auto smallest_succ_iter = this->lane_key_to_successors.find(smallest);
-        if (smallest_succ_iter == this->lane_key_to_successors.end())
-            continue;
-
-        for (const auto& successor : smallest_succ_iter->second)
+        // Iterate over successors
+        for (const auto& weighted_successor : succ_itr->second)
         {
-            const double alt = weights.at(smallest) + successor.weight;
-            if (alt < weights.at(successor))
+            LaneKey neighbor = weighted_successor;
+            double  weight = weighted_successor.weight;
+            // ...
+            // Check if neighbor is in cost_from_start before using at()
+            double current_cost =
+                (cost_from_start.find(neighbor) != cost_from_start.end()) ? cost_from_start[neighbor] : std::numeric_limits<double>::max();
+
+            double alternative_path_cost = cost_from_start[current] + weight;
+            if (alternative_path_cost < current_cost)
             {
-                weights[successor] = alt;
-                previous.insert({successor, smallest});
-                std::make_heap(nodes.begin(), nodes.end(), comparator);
+                cost_from_start[neighbor] = alternative_path_cost;
+                came_from[neighbor] = current;
+                open_set.push(WeightedLaneKey(neighbor, alternative_path_cost));
             }
         }
     }
-
-    path.push_back(from);
-    std::reverse(path.begin(), path.end());
-    return path;
+    std::cout << "did not find route" << std::endl;
+    // No path found
+    return {};
 }
 
 } // namespace odr


### PR DESCRIPTION
fixes the issue #77 :

https://github.com/pageldev/libOpenDRIVE/issues/77

Changes:
- added operators == and != to lanekeys
- reimplemented get_routing_graph (using existing junction parsing)
- reimplemented shortest_path
