### PR TITLE
added std prefix to abs function calls in OpenDriveMap.cpp

### DIFF
--- a/src/OpenDriveMap.cpp
+++ b/src/OpenDriveMap.cpp
@@ -256,12 +256,12 @@ OpenDriveMap::OpenDriveMap(const std::string& xodr_file,
                 }
                 else
                 {
-                    if (abs(curv_start) < 1e-6 && abs(curv_end) < 1e-6)
+                    if (std::abs(curv_start) < 1e-6 && std::abs(curv_end) < 1e-6)
                     {
                         // In effect a line
                         road.ref_line.s0_to_geometry[s0] = std::make_unique<Line>(s0, x0, y0, hdg0, length);
                     }
-                    else if (abs(curv_end - curv_start) < 1e-6)
+                    else if (std::abs(curv_end - curv_start) < 1e-6)
                     {
                         // In effect an arc
                         road.ref_line.s0_to_geometry[s0] = std::make_unique<Arc>(s0, x0, y0, hdg0, length, curv_start);


### PR DESCRIPTION
Due to the missing std prefix, my compiler was matching the calls to the int abs(int) function on my system, which led to any spiral with a curvature below 1 being interpreted as line or arc. I was using CMake to build the library on Ubuntu 22.04, the compiler was gcc 11.4.0. I think changing this also makes it more consistent with the rest of your library, where you seem to be using std::abs() as well.