### PR TITLE
Update doc regarding default static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-project(libOpenDrive VERSION 0.3.0 DESCRIPTION ".xodr library")
+project(libOpenDrive VERSION 0.6.0 DESCRIPTION ".xodr library")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,19 @@ std::cout << road_network_mesh.get_mesh().get_obj() << std::endl;
 ```
 
 ## Build
-To build the library simply run:
+To build a static library by default, simply run:
 ```bash
 mkdir build && cd build
 cmake ..
 make
 ```
 
-This also builds an executable to test the library:
+If requiring a shared library, use:
+```bash
+cmake .. -DBUILD_SHARED_LIBS=ON
+```
+
+The build also provides an executable to test the library:
 ```bash
 ./build/test-xodr test.xodr
 ```


### PR DESCRIPTION
With the recent commits, the default building behaviour has changed from a shared to a static library which might be worth mentioning in the building hints.

Connected thoughts:

1. It could be practical to add a new version tag `0.6.0` for the changed default CMake building configuration. Reason: Some depending build chains will require reconfiguration if they have been linking libOpenDRIVE as shared lib without setting the according CMake variable explicitly.
2. Regarding the current Git version tag `0.5.0` I see that it is not in sync with the CMake project version which still states being `0.3.0`. If libOpenDRIVE serves as CMake dependency in other software, it will be of relevance sooner or later. https://github.com/pageldev/libOpenDRIVE/blob/9a0437f8a18d445d5c43fe2a4c9401d8a4b770f0/CMakeLists.txt#L7