### PR TITLE
Expose xml_parse_result for external queryability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-project(libOpenDrive VERSION 0.3.0 DESCRIPTION ".xodr library")
+project(libOpenDrive VERSION 0.6.0 DESCRIPTION ".xodr library")
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 

--- a/include/OpenDriveMap.h
+++ b/include/OpenDriveMap.h
@@ -36,6 +36,7 @@ public:
     double             y_offs = 0;
     const std::string  xodr_file = "";
     pugi::xml_document xml_doc;
+    pugi::xml_parse_result xml_parse_result;
 
     std::map<std::string, Road>     id_to_road;
     std::map<std::string, Junction> id_to_junction;

--- a/src/OpenDriveMap.cpp
+++ b/src/OpenDriveMap.cpp
@@ -64,9 +64,9 @@ OpenDriveMap::OpenDriveMap(const std::string& xodr_file,
                            const bool         with_road_signals) :
     xodr_file(xodr_file)
 {
-    pugi::xml_parse_result result = this->xml_doc.load_file(xodr_file.c_str());
-    if (!result)
-        printf("%s\n", result.description());
+    this->xml_parse_result = this->xml_doc.load_file(xodr_file.c_str());
+    if (!this->xml_parse_result)
+        printf("%s\n", this->xml_parse_result.description());
 
     pugi::xml_node odr_node = this->xml_doc.child("OpenDRIVE");
 


### PR DESCRIPTION
Currently, when including libOpenDRIVE in an external project, there is no possibility to elegantly catch XML parsing errors. The reason is that "most pugixml functions have a no-throw exception guarantee" and that libOpenDRIVE itself does not expose any additional exception handling possibility.

Exposing `pugi::xml_parse_result` as member variable of `OpenDriveMap` enables [handling of parsing errors](https://pugixml.org/docs/manual.html#loading.errors) by querying the `xml_parse_status` from within the external project.