### PR TITLE
fix: add odrSpiral to odr namespace

### DIFF
--- a/include/Geometries/Spiral/odrSpiral.h
+++ b/include/Geometries/Spiral/odrSpiral.h
@@ -32,4 +32,7 @@
  * @param t      tangent direction at s [rad]
  */
 
+namespace odr
+{
 extern void odrSpiral(double s, double cDot, double* x, double* y, double* t);
+}; // namespace odr

--- a/src/Geometries/Spiral/odrSpiral.cpp
+++ b/src/Geometries/Spiral/odrSpiral.cpp
@@ -39,6 +39,9 @@
 #define _USE_MATH_DEFINES
 #include <math.h>
 
+namespace odr
+{
+
 /* ====== LOCAL VARIABLES ====== */
 
 /* S(x) for small x */
@@ -241,3 +244,5 @@ void odrSpiral(double s, double cDot, double* x, double* y, double* t)
 
     *t = s * s * cDot * 0.5;
 }
+
+}; // namespace odr


### PR DESCRIPTION
This resolves the build issues with an external tool described in #99 .