### PR TITLE
include order in RoadObject.h causing error in MSVC

### DIFF
--- a/include/RoadObject.h
+++ b/include/RoadObject.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "LaneValidityRecord.h"
 #include "Math.hpp"
+#include "LaneValidityRecord.h"
 #include "Mesh.h"
 #include "XmlNode.h"
 


### PR DESCRIPTION
Trying to compile using Visual Studio 17 (Visual C++ 2022), I get the following errors:

```
D:\local\src\libOpenDRIVE\src\RoadObject.cpp(67): error C2065: 'M_PI': undeclared identifier
D:\local\src\libOpenDRIVE\src\RoadObject.cpp(66): error C2737: 'eps_angle': const object must be initialized
D:\local\src\libOpenDRIVE\src\RoadObject.cpp(70): error C2065: 'M_PI': undeclared identifier
D:\local\src\libOpenDRIVE\src\RoadObject.cpp(72): error C2065: 'M_PI': undeclared identifier
```

It seems that for MSVC, `#define _USE_MATH_DEFINES` must be set *before* the first time that `<cmath>` is included, otherwise it does not take effect.

The proposed swap in include order makes it compile successfuly on my side.
